### PR TITLE
DM-7826 Add zoom and pan to Firefly widgets

### DIFF
--- a/examples/Image Zoom and Pan Test.ipynb
+++ b/examples/Image Zoom and Pan Test.ipynb
@@ -1,0 +1,346 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For this test, we will place two widgets side-by-side."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The following line is needed to load the Firefly Javascript API into the DOM. The url can be changed to a remote instance, of course."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from firefly_widgets import connect\n",
+    "connect('http://irsa.ipac.caltech.edu:80/irsaviewer')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from ipywidgets import Layout"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from firefly_widgets import ImageViewer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Currently the image viewer queries a service for 2MASS images by default."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "iv = ImageViewer(WorldPt='283.396163;+33.029175;EQ_J2000', GridOn=False,\n",
+    "                 layout=Layout(width='400px', height='400px'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "If a path or URL is given to ImageViewer, it will read in the specified image instead of querying an archive."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "mypath = ('http://web.ipac.caltech.edu/staff/roby/demo/wise-m51-band4.fits')\n",
+    "fv = ImageViewer(url=mypath, gridOn=False,\n",
+    "                 layout=Layout(width='400px', height='400px'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from ipywidgets import HBox, VBox, IntSlider, FloatSlider, jslink"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "izoom1 = FloatSlider(\n",
+    "    value=1.0,\n",
+    "    min=0.1,\n",
+    "    max=10.0,\n",
+    "    step=0.1,\n",
+    "    description='Left Zoom',\n",
+    "    disabled=False,\n",
+    "    continuous_update=False,\n",
+    "    orientation='horizontal',\n",
+    "    readout=True,\n",
+    "    readout_format='.1f',\n",
+    "    slider_color='white'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "ix1 = IntSlider(\n",
+    "    value=10,\n",
+    "    min=0,\n",
+    "    max=400,\n",
+    "    step=1,\n",
+    "    description='Left x_pan',\n",
+    "    disabled=False,\n",
+    "    continuous_update=False,\n",
+    "    orientation='horizontal',\n",
+    "    readout=True,\n",
+    "    readout_format='i',\n",
+    "    slider_color='white'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "iy1 = IntSlider(\n",
+    "    value=20,\n",
+    "    min=0,\n",
+    "    max=400,\n",
+    "    step=1,\n",
+    "    description='Left y_pan',\n",
+    "    disabled=False,\n",
+    "    continuous_update=False,\n",
+    "    orientation='horizontal',\n",
+    "    readout=True,\n",
+    "    readout_format='i',\n",
+    "    slider_color='white'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "izoom2 = FloatSlider(\n",
+    "    value=1.0,\n",
+    "    min=0.1,\n",
+    "    max=10.0,\n",
+    "    step=0.1,\n",
+    "    description='Left Zoom',\n",
+    "    disabled=False,\n",
+    "    continuous_update=False,\n",
+    "    orientation='horizontal',\n",
+    "    readout=True,\n",
+    "    readout_format='.1f',\n",
+    "    slider_color='white'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "ix2 = IntSlider(\n",
+    "    value=10,\n",
+    "    min=0,\n",
+    "    max=400,\n",
+    "    step=1,\n",
+    "    description='Left x_pan',\n",
+    "    disabled=False,\n",
+    "    continuous_update=False,\n",
+    "    orientation='horizontal',\n",
+    "    readout=True,\n",
+    "    readout_format='i',\n",
+    "    slider_color='white'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "iy2 = IntSlider(\n",
+    "    value=20,\n",
+    "    min=0,\n",
+    "    max=400,\n",
+    "    step=1,\n",
+    "    description='Left y_pan',\n",
+    "    disabled=False,\n",
+    "    continuous_update=False,\n",
+    "    orientation='horizontal',\n",
+    "    readout=True,\n",
+    "    readout_format='i',\n",
+    "    slider_color='white'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "left_link_zoom = jslink((izoom1, 'value'), (iv, 'zoom'))\n",
+    "left_link_xpan = jslink((ix1, 'value'), (iv, 'x_pan'))\n",
+    "left_link_ypan = jslink((iy1, 'value'), (iv, 'y_pan'))\n",
+    "right_link_zoom = jslink((izoom2, 'value'), (fv, 'zoom'))\n",
+    "right_link_xpan = jslink((ix2, 'value'), (fv, 'x_pan'))\n",
+    "right_link_ypan = jslink((iy2, 'value'), (fv, 'y_pan'))\n",
+    "both_link_zoom = jslink((izoom1, 'value'), (izoom2, 'value'))\n",
+    "both_link_xpan = jslink((ix1, 'value'), (ix2, 'value'))\n",
+    "both_link_ypan = jslink((iy1, 'value'), (iy2, 'value'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Activate \"Lock by click\" in the image toolbar (with cursor inside an image widget) to pan to a position by clicking on that point."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "HBox([VBox([izoom1,ix1,iy1,iv]),VBox([izoom2,ix2,iy2,fv])])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Programmatically change the zoom"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "iv.zoom = 4.0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "iv.zoom"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fv.zoom"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.1"
+  },
+  "widgets": {
+   "state": {},
+   "version": "1.1.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/examples/Images and Tables.ipynb
+++ b/examples/Images and Tables.ipynb
@@ -78,6 +78,55 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Select \"Lock by click\" in the toolbar to activate panning to that point."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "iv.x_pan"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "iv.y_pan= -40"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "iv.zoom = 3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "iv.zoom"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Turn on the coordinate grid."
    ]
   },
@@ -131,7 +180,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "iv.colorbar"
@@ -163,7 +214,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "tv"
@@ -172,7 +225,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "tv.filters"
@@ -211,7 +266,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "mytable"
@@ -242,7 +299,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "fv"
@@ -262,7 +321,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "fv.colorbar"
@@ -292,7 +353,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "dtv"
@@ -301,7 +364,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "dtv.filters"

--- a/firefly_widgets/image.py
+++ b/firefly_widgets/image.py
@@ -1,5 +1,5 @@
 import ipywidgets as widgets
-from traitlets import Unicode, Bool, Integer, TraitError, validate
+from traitlets import Unicode, Bool, Integer, Float, TraitError, validate
 
 
 @widgets.register('Image')
@@ -19,6 +19,9 @@ class ImageViewer(widgets.DOMWidget):
     SizeInDeg = Unicode('.12').tag(sync=True)
     url = Unicode('').tag(sync=True)
     colorbar = Integer(0).tag(sync=True)
+    x_pan = Float(1.0).tag(sync=True)
+    y_pan = Float(1.0).tag(sync=True)
+    zoom = Float(1.0).tag(sync=True)
 
     @validate('colorbar')
     def _valid_colorbar(self, proposal):


### PR DESCRIPTION
Add zoom and pan to Firefly widgets.

- implement zoom, x_pan, y_pan attributes
- make the attributes sync in both directions (front-end and Python session)
- make an example notebook

Panning using the mouse is implemented as picking a point, after "Lock by click" is selected in the toolbar for an image widget.