### PR TITLE
DM-11341 Firefly exception when creating a widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ For a development installation (requires npm),
 
 When using the widgets, if a warning about missing widgetsnbextension appears, follow the instructions in the warning to install it. Installed nbextensions can be listed with:
 
-    $ jupyter nbextensions list
+    $ jupyter nbextension list
 
 For further development:
  - Javascript side:

--- a/examples/Image Colorbar Test.ipynb
+++ b/examples/Image Colorbar Test.ipynb
@@ -27,9 +27,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from ipywidgets import Layout"
@@ -38,9 +36,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from firefly_widgets import ImageViewer"
@@ -56,9 +52,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "iv = ImageViewer(WorldPt='283.396163;+33.029175;EQ_J2000', GridOn=False,\n",
@@ -77,9 +71,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "mypath = ('http://web.ipac.caltech.edu/staff/roby/demo/wise-m51-band4.fits')\n",
@@ -90,9 +82,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from ipywidgets import HBox, VBox, IntSlider, jslink"
@@ -101,9 +91,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "iw1 = IntSlider(\n",
@@ -116,7 +104,7 @@
     "    continuous_update=False,\n",
     "    orientation='horizontal',\n",
     "    readout=True,\n",
-    "    readout_format='i',\n",
+    "    readout_format='d',\n",
     "    slider_color='white'\n",
     ")"
    ]
@@ -124,9 +112,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "iw2 = IntSlider(\n",
@@ -139,7 +125,7 @@
     "    continuous_update=False,\n",
     "    orientation='horizontal',\n",
     "    readout=True,\n",
-    "    readout_format='i',\n",
+    "    readout_format='d',\n",
     "    slider_color='white'\n",
     ")"
    ]
@@ -147,9 +133,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "left_link = jslink((iw1, 'value'), (iv, 'colorbar'))\n",
@@ -176,9 +160,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "both_link.unlink()"
@@ -194,9 +176,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "both_link = jslink((iw1, 'value'), (iw2, 'value'))"
@@ -212,9 +192,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "iv.colorbar = 21"
@@ -223,9 +201,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "iv.colorbar"
@@ -234,9 +210,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fv.colorbar = 9"
@@ -245,9 +219,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fv.colorbar"
@@ -263,9 +235,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "iv.GridOn = True"
@@ -281,9 +251,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "iv.SurveyKey = 'h'"
@@ -292,9 +260,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   }
@@ -302,21 +268,21 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
   },
   "widgets": {
    "state": {},

--- a/examples/Image Colorbar Test.ipynb
+++ b/examples/Image Colorbar Test.ipynb
@@ -21,13 +21,16 @@
    "outputs": [],
    "source": [
     "from firefly_widgets import connect\n",
-    "connect('http://irsa.ipac.caltech.edu:80/irsaviewer')"
+    "#connect('http://irsa.ipac.caltech.edu:80/irsaviewer')\n",
+    "connect('http://localhost:8080/firefly')"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from ipywidgets import Layout"
@@ -36,7 +39,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from firefly_widgets import ImageViewer"
@@ -52,7 +57,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "iv = ImageViewer(WorldPt='283.396163;+33.029175;EQ_J2000', GridOn=False,\n",
@@ -71,7 +78,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "mypath = ('http://web.ipac.caltech.edu/staff/roby/demo/wise-m51-band4.fits')\n",
@@ -82,7 +91,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from ipywidgets import HBox, VBox, IntSlider, jslink"
@@ -91,7 +102,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "iw1 = IntSlider(\n",
@@ -112,7 +125,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "iw2 = IntSlider(\n",
@@ -133,7 +148,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "left_link = jslink((iw1, 'value'), (iv, 'colorbar'))\n",
@@ -160,7 +177,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "both_link.unlink()"
@@ -176,7 +195,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "both_link = jslink((iw1, 'value'), (iw2, 'value'))"
@@ -192,7 +213,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "iv.colorbar = 21"
@@ -201,7 +224,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "iv.colorbar"
@@ -210,7 +235,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "fv.colorbar = 9"
@@ -219,7 +246,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "fv.colorbar"
@@ -235,7 +264,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "iv.GridOn = True"
@@ -251,7 +282,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "iv.SurveyKey = 'h'"
@@ -260,7 +293,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": []
   }
@@ -268,21 +303,21 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.3"
   },
   "widgets": {
    "state": {},

--- a/examples/Image Zoom and Pan Test.ipynb
+++ b/examples/Image Zoom and Pan Test.ipynb
@@ -17,17 +17,22 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from firefly_widgets import connect\n",
-    "connect('http://irsa.ipac.caltech.edu:80/irsaviewer')"
+    "#connect('http://irsa.ipac.caltech.edu:80/irsaviewer')\n",
+    "connect('http://localhost:8080/firefly')"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from ipywidgets import Layout"
@@ -36,7 +41,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from firefly_widgets import ImageViewer"
@@ -52,7 +59,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "iv = ImageViewer(WorldPt='283.396163;+33.029175;EQ_J2000', GridOn=False,\n",
@@ -71,7 +80,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "mypath = ('http://web.ipac.caltech.edu/staff/roby/demo/wise-m51-band4.fits')\n",
@@ -82,7 +93,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from ipywidgets import HBox, VBox, IntSlider, FloatSlider, jslink"
@@ -91,7 +104,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "izoom1 = FloatSlider(\n",
@@ -112,7 +127,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "ix1 = IntSlider(\n",
@@ -133,7 +150,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "iy1 = IntSlider(\n",
@@ -154,7 +173,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "izoom2 = FloatSlider(\n",
@@ -175,7 +196,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "ix2 = IntSlider(\n",
@@ -196,7 +219,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "iy2 = IntSlider(\n",
@@ -217,7 +242,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "left_link_zoom = jslink((izoom1, 'value'), (iv, 'zoom'))\n",
@@ -241,7 +268,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "HBox([VBox([izoom1,ix1,iy1,iv]),VBox([izoom2,ix2,iy2,fv])])"
@@ -257,7 +286,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "iv.zoom = 4.0"
@@ -266,7 +297,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "iv.zoom"
@@ -275,7 +308,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "fv.zoom"
@@ -284,7 +319,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": []
   }
@@ -292,21 +329,21 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,

--- a/examples/Image Zoom and Pan Test.ipynb
+++ b/examples/Image Zoom and Pan Test.ipynb
@@ -27,9 +27,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from ipywidgets import Layout"
@@ -38,9 +36,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from firefly_widgets import ImageViewer"
@@ -56,9 +52,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "iv = ImageViewer(WorldPt='283.396163;+33.029175;EQ_J2000', GridOn=False,\n",
@@ -77,9 +71,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "mypath = ('http://web.ipac.caltech.edu/staff/roby/demo/wise-m51-band4.fits')\n",
@@ -90,9 +82,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from ipywidgets import HBox, VBox, IntSlider, FloatSlider, jslink"
@@ -101,9 +91,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "izoom1 = FloatSlider(\n",
@@ -124,9 +112,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "ix1 = IntSlider(\n",
@@ -139,7 +125,7 @@
     "    continuous_update=False,\n",
     "    orientation='horizontal',\n",
     "    readout=True,\n",
-    "    readout_format='i',\n",
+    "    readout_format='d',\n",
     "    slider_color='white'\n",
     ")"
    ]
@@ -147,9 +133,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "iy1 = IntSlider(\n",
@@ -162,7 +146,7 @@
     "    continuous_update=False,\n",
     "    orientation='horizontal',\n",
     "    readout=True,\n",
-    "    readout_format='i',\n",
+    "    readout_format='d',\n",
     "    slider_color='white'\n",
     ")"
    ]
@@ -170,9 +154,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "izoom2 = FloatSlider(\n",
@@ -193,9 +175,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "ix2 = IntSlider(\n",
@@ -208,7 +188,7 @@
     "    continuous_update=False,\n",
     "    orientation='horizontal',\n",
     "    readout=True,\n",
-    "    readout_format='i',\n",
+    "    readout_format='d',\n",
     "    slider_color='white'\n",
     ")"
    ]
@@ -216,9 +196,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "iy2 = IntSlider(\n",
@@ -231,7 +209,7 @@
     "    continuous_update=False,\n",
     "    orientation='horizontal',\n",
     "    readout=True,\n",
-    "    readout_format='i',\n",
+    "    readout_format='d',\n",
     "    slider_color='white'\n",
     ")"
    ]
@@ -239,9 +217,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "left_link_zoom = jslink((izoom1, 'value'), (iv, 'zoom'))\n",
@@ -281,9 +257,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "iv.zoom = 4.0"
@@ -310,9 +284,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   }
@@ -320,25 +292,21 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.1"
-  },
-  "widgets": {
-   "state": {},
-   "version": "1.1.2"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,

--- a/examples/Images and Tables.ipynb
+++ b/examples/Images and Tables.ipynb
@@ -38,9 +38,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from firefly_widgets import ImageViewer"
@@ -56,9 +54,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "iv = ImageViewer(WorldPt='283.396163;+33.029175;EQ_J2000', GridOn=False,\n",
@@ -93,9 +89,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "iv.y_pan= 100"
@@ -104,9 +98,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "iv.zoom = 1.5"
@@ -115,9 +107,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "iv.zoom"
@@ -133,9 +123,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "iv.GridOn = True"
@@ -151,9 +139,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "iv.SurveyKey = 'h'"
@@ -169,9 +155,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "iv.colorbar = 15"
@@ -180,9 +164,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "iv.colorbar"
@@ -191,9 +173,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from firefly_widgets import TableViewer"
@@ -202,9 +182,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "tv = TableViewer(position='283.396163;+33.029175;EQ_J2000',\n",
@@ -214,9 +192,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "tv"
@@ -225,9 +201,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "tv.filters"
@@ -236,9 +210,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "tv.filters = 'w3snr > 10'\n",
@@ -255,9 +227,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "mytable = tv.selection()"
@@ -266,9 +236,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "mytable"
@@ -286,9 +254,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "mypath = ('http://web.ipac.caltech.edu/staff/roby/demo/wise-m51-band4.fits')\n",
@@ -299,9 +265,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fv"
@@ -310,9 +274,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fv.colorbar = 9"
@@ -321,9 +283,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fv.colorbar"
@@ -341,9 +301,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "dtv = TableViewer(url_or_path='http://web.ipac.caltech.edu/staff/roby/demo/WiseDemoTable.tbl',\n",
@@ -353,9 +311,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "dtv"
@@ -364,9 +320,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "dtv.filters"
@@ -375,9 +329,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   }
@@ -385,21 +337,21 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,

--- a/examples/Images and Tables.ipynb
+++ b/examples/Images and Tables.ipynb
@@ -195,80 +195,29 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "scrolled": false
    },
    "outputs": [],
    "source": [
-    "from firefly_widgets import TableViewer"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "tv = TableViewer(position='283.396163;+33.029175;EQ_J2000',\n",
-    "                 layout=Layout(width='600px', height='400px'))"
+    "from firefly_widgets import TableViewer, ChartViewer\n",
+    "tv = TableViewer(position='285.396163;+33.029175;EQ_J2000',layout=Layout(width='600px', height='400px'))            \n",
+    "display(tv)  \n",
+    "\n",
+    "# when the table is displayed, its tbl_group is set by Firefly\n",
+    "# observe this change and display a chart connected to this table\n",
+    "# the table and the chart share common data, filters, highlight, and selected rows\n",
+    "def on_tbl_group_change(change):\n",
+    "    cv = ChartViewer(layout=Layout(width='600px', height='400px'), tbl_group=change['new'])\n",
+    "    print('The default chart for table group '+tv.tbl_group)\n",
+    "    display(cv)\n",
+    "\n",
+    "tv.observe(on_tbl_group_change, names='tbl_group')"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
-   "source": [
-    "tv"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "from firefly_widgets import ChartViewer"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "cv = ChartViewer(layout=Layout(width='600px', height='400px'))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "cv.keys"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "cv"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
    "outputs": [],
    "source": [
     "tv.filters"
@@ -282,7 +231,7 @@
    },
    "outputs": [],
    "source": [
-    "tv.filters = 'w3snr > 10'\n",
+    "tv.filters = '\"w3snr\" > 10'\n",
     "tv.pageSize = 15"
    ]
   },

--- a/examples/Images and Tables.ipynb
+++ b/examples/Images and Tables.ipynb
@@ -14,7 +14,8 @@
    "outputs": [],
    "source": [
     "from firefly_widgets import connect\n",
-    "connect('http://irsa.ipac.caltech.edu:80/irsaviewer')"
+    "#connect('http://irsa.ipac.caltech.edu:80/irsaviewer')\n",
+    "connect('http://localhost:8080/firefly')"
    ]
   },
   {
@@ -38,7 +39,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from firefly_widgets import ImageViewer"
@@ -54,7 +57,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "iv = ImageViewer(WorldPt='283.396163;+33.029175;EQ_J2000', GridOn=False,\n",
@@ -80,7 +85,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "iv.x_pan = 150"
@@ -89,7 +96,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "iv.y_pan= 100"
@@ -98,7 +107,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "iv.zoom = 1.5"
@@ -107,7 +118,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "iv.zoom"
@@ -123,7 +136,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "iv.GridOn = True"
@@ -139,7 +154,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "iv.SurveyKey = 'h'"
@@ -155,7 +172,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "iv.colorbar = 15"
@@ -164,7 +183,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "iv.colorbar"
@@ -173,7 +194,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from firefly_widgets import TableViewer"
@@ -182,7 +205,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "tv = TableViewer(position='283.396163;+33.029175;EQ_J2000',\n",
@@ -201,7 +226,49 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from firefly_widgets import ChartViewer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "cv = ChartViewer(layout=Layout(width='600px', height='400px'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
+   "source": [
+    "cv.keys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cv"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "tv.filters"
@@ -210,7 +277,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "tv.filters = 'w3snr > 10'\n",
@@ -227,7 +296,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "mytable = tv.selection()"
@@ -236,7 +307,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "mytable"
@@ -254,7 +327,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "mypath = ('http://web.ipac.caltech.edu/staff/roby/demo/wise-m51-band4.fits')\n",
@@ -265,7 +340,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "fv"
@@ -274,7 +351,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "fv.colorbar = 9"
@@ -283,7 +362,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "fv.colorbar"
@@ -301,7 +382,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "dtv = TableViewer(url_or_path='http://web.ipac.caltech.edu/staff/roby/demo/WiseDemoTable.tbl',\n",
@@ -311,7 +394,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "dtv"
@@ -320,7 +405,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "dtv.filters"
@@ -329,7 +416,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": []
   }
@@ -337,21 +426,21 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,

--- a/firefly_widgets/__init__.py
+++ b/firefly_widgets/__init__.py
@@ -2,6 +2,7 @@ from ._version import version_info, __version__
 
 from .image import *
 from .table import *
+from .chart import *
 from .utils import connect
 
 

--- a/firefly_widgets/_version.py
+++ b/firefly_widgets/_version.py
@@ -1,4 +1,4 @@
-version_info = (0, 1, 0, 'beta', 5)
+version_info = (0, 1, 0, 'beta', 6)
 _specifier_ = {'alpha': 'a', 'beta': 'b', 'candidate': 'rc', 'final': ''}
 
 __version__ = '%s.%s.%s%s'%(version_info[0], version_info[1], version_info[2],

--- a/firefly_widgets/_version.py
+++ b/firefly_widgets/_version.py
@@ -1,2 +1,5 @@
-version_info = (0, 1, '0-beta5')
-__version__ = '.'.join(map(str, version_info))
+version_info = (0, 1, 0, 'beta', 5)
+_specifier_ = {'alpha': 'a', 'beta': 'b', 'candidate': 'rc', 'final': ''}
+
+__version__ = '%s.%s.%s%s'%(version_info[0], version_info[1], version_info[2],
+  '' if version_info[3]=='final' else _specifier_[version_info[3]]+str(version_info[4]))

--- a/firefly_widgets/chart.py
+++ b/firefly_widgets/chart.py
@@ -1,0 +1,12 @@
+import ipywidgets as widgets
+from traitlets import Unicode
+
+
+@widgets.register
+class ChartViewer(widgets.DOMWidget):
+    """
+    Chart Viewer widget
+    """
+    _view_name = Unicode('ChartView').tag(sync=True)
+    _view_module = Unicode('jupyter-firefly').tag(sync=True)
+    tbl_group = Unicode().tag(sync=True)

--- a/firefly_widgets/image.py
+++ b/firefly_widgets/image.py
@@ -2,7 +2,7 @@ import ipywidgets as widgets
 from traitlets import Unicode, Bool, Integer, Float, TraitError, validate
 
 
-@widgets.register('Image')
+@widgets.register
 class ImageViewer(widgets.DOMWidget):
     """
     Image Viewer widget

--- a/firefly_widgets/table.py
+++ b/firefly_widgets/table.py
@@ -4,7 +4,7 @@ from astropy.table import Table
 from six.moves.urllib.request import urlopen
 
 
-@widgets.register('Table')
+@widgets.register
 class TableViewer(widgets.DOMWidget):
     """
     Linked Table Viewer widget

--- a/firefly_widgets/table.py
+++ b/firefly_widgets/table.py
@@ -17,6 +17,7 @@ class TableViewer(widgets.DOMWidget):
     radius = Int(300).tag(sync=True)
     url_or_path = Unicode().tag(sync=True)
     data_url = Unicode().tag(sync=True)
+    tbl_group = Unicode().tag(sync=True)
 
     def selection(self):
         """

--- a/firefly_widgets/utils.py
+++ b/firefly_widgets/utils.py
@@ -1,4 +1,3 @@
-
 from __future__ import print_function
 from IPython.core.display import HTML
 from IPython.display import display

--- a/js/package.json
+++ b/js/package.json
@@ -15,16 +15,21 @@
     "ipython",
     "ipywidgets"
   ],
+  "files": [
+    "src/**/*.js",
+    "dist/*.js"
+  ],
   "scripts": {
+    "clean": "rimraf dist/",
     "prepublish": "webpack",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {
-    "json-loader": "^0.5.4",
-    "webpack": "^1.12.14"
+    "webpack": "^3.5.5",
+    "rimraf": "^2.6.1"
   },
   "dependencies": {
-    "jupyter-js-widgets": "^2.1.4",
-    "underscore": "^1.8.3"
+    "@jupyter-widgets/base": "^1.0.0",
+    "lodash": "^4.17.4"
   }
 }

--- a/js/src/Chart.js
+++ b/js/src/Chart.js
@@ -33,8 +33,7 @@ var ChartView = widgets.DOMWidgetView.extend({
     },
 
     redraw: function() {
-        var tbl_group =  this.model.get('tbl_group');
-        firefly.showChart(this.el.id, {tbl_group: tbl_group || 'main'});
+        firefly.showChart(this.el.id, {tbl_group: this.model.get('tbl_group')});
     }
 
 });

--- a/js/src/Chart.js
+++ b/js/src/Chart.js
@@ -1,0 +1,46 @@
+var widgets = require('@jupyter-widgets/base');
+var _ = require('lodash');
+
+// Custom Model. Custom widgets models must at least provide default values
+// for model attributes, including `_model_name`, `_view_name`, `_model_module`
+// and `_view_module` when different from the base class.
+//
+// When serialiazing entire widget state for embedding, only values different from the
+// defaults will be specified.
+var ChartModel = widgets.DOMWidgetModel.extend({
+    defaults: _.extend(widgets.DOMWidgetModel.prototype.defaults(), {
+        _model_name : 'ChartModel',
+        _view_name : 'ChartView',
+        _model_module : 'jupyter-firefly',
+        _view_module : 'jupyter-firefly'
+    })
+});
+
+var seq = 1;
+
+// Custom View. Renders the widget model.
+var ChartView = widgets.DOMWidgetView.extend({
+    render: function() {
+        this.el.id = `ChartViewer-${seq++}`;
+        // disable Jupyter notebook keyboard manager
+        // shortcut handling prevents input into dialog fields
+        this.el.onclick = () => {
+            Jupyter.keyboard_manager.disable();
+        };
+        this.model.on('change:tbl_group', this.redraw, this);
+        this.redraw = this.redraw.bind(this);
+        setTimeout(this.redraw, 0);
+    },
+
+    redraw: function() {
+        var tbl_group =  this.model.get('tbl_group');
+        firefly.showChart(this.el.id, {tbl_group: tbl_group || 'main'});
+    }
+
+});
+
+
+module.exports = {
+    ChartModel : ChartModel,
+    ChartView : ChartView
+};

--- a/js/src/Image.js
+++ b/js/src/Image.js
@@ -1,5 +1,5 @@
-var widgets = require('jupyter-js-widgets');
-var _ = require('underscore');
+var widgets = require('@jupyter-widgets/base');
+var _ = require('lodash');
 
 
 // Custom Model. Custom widgets models must at least provide default values
@@ -9,7 +9,7 @@ var _ = require('underscore');
 // When serialiazing entire widget state for embedding, only values different from the
 // defaults will be specified.
 var ImageModel = widgets.DOMWidgetModel.extend({
-    defaults: _.extend(_.result(this, 'widgets.DOMWidgetModel.prototype.defaults'), {
+    defaults: _.extend(widgets.DOMWidgetModel.prototype.defaults(), {
         _model_name : 'ImageModel',
         _view_name : 'ImageView',
         _model_module : 'jupyter-firefly',
@@ -83,7 +83,7 @@ var ImageView = widgets.DOMWidgetView.extend({
         if (action.payload.plotId === this.req.plotId) {
             var cbarId = Number(action.payload.primaryStateJson.colorTableId);
             var o_colorbar = Number(this.model.get('colorbar'));
-            var mymodel = this.model;
+            //var mymodel = this.model;
             console.log('I got a color change, colorbar = ' + cbarId);
             console.log('model colorbar = ' + o_colorbar);
             if (cbarId != o_colorbar){
@@ -106,7 +106,7 @@ var ImageView = widgets.DOMWidgetView.extend({
         if (action.payload.plotId === this.req.plotId) {
             var plot= util.image.getPrimePlot( action.payload.plotId);  // get the plot
             console.log('I got a replot, zoom factor= ' + plot.zoomFactor);
-            zoom_factor = Math.round(parseFloat(plot.zoomFactor)*100)/100
+            zoom_factor = Math.round(parseFloat(plot.zoomFactor)*100)/100;
             var o_zoom = Math.round(this.model.get('zoom')*100)/100;
             console.log('model zoom = ' + o_zoom);
             if (zoom_factor != o_zoom){
@@ -144,7 +144,7 @@ var ImageView = widgets.DOMWidgetView.extend({
             this.model.set('WorldPt', worldPt);
             this.touch();
         }
-     },
+     }
 
 });
 

--- a/js/src/Image.js
+++ b/js/src/Image.js
@@ -6,7 +6,7 @@ var _ = require('lodash');
 // for model attributes, including `_model_name`, `_view_name`, `_model_module`
 // and `_view_module` when different from the base class.
 //
-// When serialiazing entire widget state for embedding, only values different from the
+// When serializing entire widget state for embedding, only values different from the
 // defaults will be specified.
 var ImageModel = widgets.DOMWidgetModel.extend({
     defaults: _.extend(widgets.DOMWidgetModel.prototype.defaults(), {
@@ -19,8 +19,8 @@ var ImageModel = widgets.DOMWidgetModel.extend({
     })
 });
 
-var util = firefly.util;
-var action = firefly.action;
+//var util = firefly.util;
+//var action = firefly.action;
 
 
 var seq = 1;
@@ -29,6 +29,11 @@ var ImageView = widgets.DOMWidgetView.extend({
     render: function() {
         this.url = this.model.get('url');
         this.el.id = `imageViewer-${seq++}`;
+        // disable Jupyter notebook keyboard manager
+        // shortcut handling prevents input into dialog fields
+        this.el.onclick = () => {
+            Jupyter.keyboard_manager.disable();
+        };
         this.req = {
             plotId    : this.el.id,
             Type      : 'SERVICE',
@@ -47,14 +52,14 @@ var ImageView = widgets.DOMWidgetView.extend({
         this.redraw = this.redraw.bind(this);
         this.update_color = this.update_color.bind(this);
         this.color_changed = this.color_changed.bind(this);
-        this.colorListner = util.addActionListener(action.type.COLOR_CHANGE, this.color_changed);
+        this.colorListner = firefly.util.addActionListener(firefly.action.type.COLOR_CHANGE, this.color_changed);
         this.update_zoom = this.update_zoom.bind(this);
         this.zoom_changed = this.zoom_changed.bind(this);
-        this.zoomListner = util.addActionListener(action.type.ZOOM_IMAGE, this.zoom_changed);
+        this.zoomListner = firefly.util.addActionListener(firefly.action.type.ZOOM_IMAGE, this.zoom_changed);
         this.update_pan = this.update_pan.bind(this);
         this.pan_changed = this.pan_changed.bind(this);
-        this.stopPickListner = util.addActionListener(action.type.SELECT_POINT, this.pan_changed);
-        //this.panListner = util.addActionListener(action.type.PROCESS_SCROLL, this.pan_changed);
+        this.stopPickListner = firefly.util.addActionListener(firefly.action.type.SELECT_POINT, this.pan_changed);
+        //this.panListner = firefly.util.addActionListener(firefly.action.type.PROCESS_SCROLL, this.pan_changed);
         setTimeout(this.redraw, 0);
     },
 
@@ -104,7 +109,7 @@ var ImageView = widgets.DOMWidgetView.extend({
 
     zoom_changed: function(action,state) {        // the callback for a zoom change
         if (action.payload.plotId === this.req.plotId) {
-            var plot= util.image.getPrimePlot( action.payload.plotId);  // get the plot
+            var plot= firefly.util.image.getPrimePlot( action.payload.plotId);  // get the plot
             console.log('I got a replot, zoom factor= ' + plot.zoomFactor);
             zoom_factor = Math.round(parseFloat(plot.zoomFactor)*100)/100;
             var o_zoom = Math.round(this.model.get('zoom')*100)/100;
@@ -121,7 +126,7 @@ var ImageView = widgets.DOMWidgetView.extend({
         console.log('updating x_pan, y_pan to ' +
                     this.model.get('x_pan') + ' ' + this.model.get('y_pan'));
         firefly.action.dispatchRecenter({plotId : this.el.id,
-                                     centerPt : util.image.makeImagePt(
+                                     centerPt : firefly.util.image.makeImagePt(
                                      Number(this.model.get('x_pan')),
                                      Number(this.model.get('y_pan')))});
     },
@@ -129,10 +134,10 @@ var ImageView = widgets.DOMWidgetView.extend({
     pan_changed: function(action,state) {        // the callback for a zoom change
          console.log('I got a scroll processed');
         if (action.payload.plotId === this.req.plotId) {
-            var plot= util.image.getPrimePlot( action.payload.plotId);  // get the plot
-            //const cc= util.image.CysConverter.make(plot);
+            //var plot= firefly.util.image.getPrimePlot( action.payload.plotId);  // get the plot
+            //const cc= firefly.util.image.CysConverter.make(plot);
             //const scrollToImagePt= cc.getImageCoords(
-            //            util.image.makeScreenPt(plot.scrollX,plot.scrollY));
+            //            firefly.util.image.makeScreenPt(plot.scrollX,plot.scrollY));
             var imagePt = String(action.payload.imagePt);
             var worldPt = String(action.payload.worldPt);
             console.log('imagePt is ' + imagePt);

--- a/js/src/Table.js
+++ b/js/src/Table.js
@@ -1,5 +1,5 @@
-var widgets = require('jupyter-js-widgets');
-var _ = require('underscore');
+var widgets = require('@jupyter-widgets/base');
+var _ = require('lodash');
 
 
 // Custom Model. Custom widgets models must at least provide default values
@@ -9,11 +9,11 @@ var _ = require('underscore');
 // When serialiazing entire widget state for embedding, only values different from the
 // defaults will be specified.
 var TableModel = widgets.DOMWidgetModel.extend({
-    defaults: _.extend({}, widgets.DOMWidgetModel.prototype.defaults, {
+    defaults: _.extend(widgets.DOMWidgetModel.prototype.defaults(), {
         _model_name : 'TableModel',
         _view_name : 'TableView',
         _model_module : 'jupyter-firefly',
-        _view_module : 'jupyter-firefly',
+        _view_module : 'jupyter-firefly'
     })
 });
 

--- a/js/src/Table.js
+++ b/js/src/Table.js
@@ -51,14 +51,16 @@ var TableView = widgets.DOMWidgetView.extend({
     },
 
     tableUpdated: function(action, state) {
-        var data_url = firefly.util.table.getTableSourceUrl(
-                        firefly.util.table.getTableUiByTblId(this.req.tbl_id));
-        this.model.set('data_url', data_url);
         if (action.payload.tbl_id === this.req.tbl_id) {
+            var data_url = firefly.util.table.getTableSourceUrl(
+                            firefly.util.table.getTableUiByTblId(this.req.tbl_id));
+            this.model.set('data_url', data_url);
+            var tbl_group = firefly.util.table.findGroupByTblId(this.req.tbl_id);
+            this.model.set('tbl_group', tbl_group);
             var o_filters = this.model.get('filters');
             var n_filters = action.payload.request.filters;
             if (o_filters != n_filters) {
-//                 this.model.set('filters', n_filters);
+                 this.model.set('filters', n_filters);
             }
         }
         this.touch();

--- a/js/src/embed.js
+++ b/js/src/embed.js
@@ -5,23 +5,6 @@
 // already be loaded by the notebook otherwise.
 
 // Export widget models and views, and the npm package version number.
-module.exports = Object.assign({}, require('./Image.js'), require('./Table.js'));
-
-//var loadedModules = [
-//	require('./Image.js'),
-//	require('./Table.js')
-//];
-//
-//for (var i in loadedModules) {
-//    if (loadedModules.hasOwnProperty(i)) {
-//        var loadedModule = loadedModules[i];
-//        for (var target_name in loadedModule) {
-//            if (loadedModule.hasOwnProperty(target_name)) {
-//                module.exports[target_name] = loadedModule[target_name];
-//            }
-//        }
-//    }
-//}
-
+module.exports = Object.assign({}, require('./Image.js'), require('./Table.js'), require('./Chart.js'));
 
 module.exports['version'] = require('../package.json').version;

--- a/js/src/embed.js
+++ b/js/src/embed.js
@@ -5,23 +5,23 @@
 // already be loaded by the notebook otherwise.
 
 // Export widget models and views, and the npm package version number.
-module.exports = {}
+module.exports = Object.assign({}, require('./Image.js'), require('./Table.js'));
 
-var loadedModules = [
-	require('./Image.js'),
-	require('./Table.js')
-];
-
-for (var i in loadedModules) {
-    if (loadedModules.hasOwnProperty(i)) {
-        var loadedModule = loadedModules[i];
-        for (var target_name in loadedModule) {
-            if (loadedModule.hasOwnProperty(target_name)) {
-                module.exports[target_name] = loadedModule[target_name];
-            }
-        }
-    }
-}
+//var loadedModules = [
+//	require('./Image.js'),
+//	require('./Table.js')
+//];
+//
+//for (var i in loadedModules) {
+//    if (loadedModules.hasOwnProperty(i)) {
+//        var loadedModule = loadedModules[i];
+//        for (var target_name in loadedModule) {
+//            if (loadedModule.hasOwnProperty(target_name)) {
+//                module.exports[target_name] = loadedModule[target_name];
+//            }
+//        }
+//    }
+//}
 
 
 module.exports['version'] = require('../package.json').version;

--- a/js/src/extension.js
+++ b/js/src/extension.js
@@ -7,8 +7,7 @@ if (window.require) {
     window.require.config({
         map: {
             "*" : {
-                "jupyter-firefly": "nbextensions/jupyter-firefly/index",
-                "jupyter-js-widgets": "nbextensions/jupyter-js-widgets/extension"
+                "jupyter-firefly": "nbextensions/jupyter-firefly/index"
             }
         }
     });

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -8,21 +8,21 @@
 __webpack_public_path__ = document.querySelector('body').getAttribute('data-base-url') + 'nbextensions/jupyter-firefly/';
 
 // Export widget models and views, and the npm package version number.
-module.exports = {}
+module.exports = Object.assign({}, require('./Image.js'), require('./Table.js'));
 
-var loadedModules = [
-	require('./Image.js'),
-	require('./Table.js')
-];
-
-for (var i in loadedModules) {
-    if (loadedModules.hasOwnProperty(i)) {
-        var loadedModule = loadedModules[i];
-        for (var target_name in loadedModule) {
-            if (loadedModule.hasOwnProperty(target_name)) {
-                module.exports[target_name] = loadedModule[target_name];
-            }
-        }
-    }
-}
+//var loadedModules = [
+//	require('./Image.js'),
+//	require('./Table.js')
+//];
+//
+//for (var i in loadedModules) {
+//    if (loadedModules.hasOwnProperty(i)) {
+//        var loadedModule = loadedModules[i];
+//        for (var target_name in loadedModule) {
+//            if (loadedModule.hasOwnProperty(target_name)) {
+//                module.exports[target_name] = loadedModule[target_name];
+//            }
+//        }
+//    }
+//}
 module.exports['version'] = require('../package.json').version;

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -8,21 +8,6 @@
 __webpack_public_path__ = document.querySelector('body').getAttribute('data-base-url') + 'nbextensions/jupyter-firefly/';
 
 // Export widget models and views, and the npm package version number.
-module.exports = Object.assign({}, require('./Image.js'), require('./Table.js'));
+module.exports = Object.assign({}, require('./Image.js'), require('./Table.js'), require('./Chart.js'));
 
-//var loadedModules = [
-//	require('./Image.js'),
-//	require('./Table.js')
-//];
-//
-//for (var i in loadedModules) {
-//    if (loadedModules.hasOwnProperty(i)) {
-//        var loadedModule = loadedModules[i];
-//        for (var target_name in loadedModule) {
-//            if (loadedModule.hasOwnProperty(target_name)) {
-//                module.exports[target_name] = loadedModule[target_name];
-//            }
-//        }
-//    }
-//}
 module.exports['version'] = require('../package.json').version;

--- a/js/webpack.config.js
+++ b/js/webpack.config.js
@@ -42,7 +42,7 @@ module.exports = [
         },
         externals: ['@jupyter-widgets/base']
     },
-    {// Embeddable {{ cookiecutter.npm_package_name }} bundle
+    {// Embeddable jupiter-firefly bundle
      //
      // This bundle is generally almost identical to the notebook bundle
      // containing the custom widget views and models.

--- a/js/webpack.config.js
+++ b/js/webpack.config.js
@@ -1,9 +1,10 @@
+var path = require('path');
 var version = require('./package.json').version;
 
-// Custom webpack loaders are generally the same for all webpack bundles, hence
+// Custom webpack rules are generally the same for all webpack bundles, hence
 // stored in a separate local variable.
-var loaders = [
-    { test: /\.json$/, loader: 'json-loader' },
+var rules = [
+    { test: /\.css$/, use: ['style-loader', 'css-loader']}
 ];
 
 
@@ -19,7 +20,7 @@ module.exports = [
         entry: './src/extension.js',
         output: {
             filename: 'extension.js',
-            path: '../firefly_widgets/static',
+            path: path.resolve(__dirname, '..', 'firefly_widgets', 'static'),
             libraryTarget: 'amd'
         }
     },
@@ -32,16 +33,16 @@ module.exports = [
         entry: './src/index.js',
         output: {
             filename: 'index.js',
-            path: '../firefly_widgets/static',
+            path: path.resolve(__dirname, '..', 'firefly_widgets', 'static'),
             libraryTarget: 'amd'
         },
         devtool: 'source-map',
         module: {
-            loaders: loaders
+            rules: rules
         },
-        externals: ['jupyter-js-widgets']
+        externals: ['@jupyter-widgets/base']
     },
-    {// Embeddable jupyter-firefly bundle
+    {// Embeddable {{ cookiecutter.npm_package_name }} bundle
      //
      // This bundle is generally almost identical to the notebook bundle
      // containing the custom widget views and models.
@@ -58,14 +59,14 @@ module.exports = [
         entry: './src/embed.js',
         output: {
             filename: 'index.js',
-            path: './dist/',
+            path: path.resolve(__dirname, 'dist'),
             libraryTarget: 'amd',
             publicPath: 'https://unpkg.com/jupyter-firefly@' + version + '/dist/'
         },
         devtool: 'source-map',
         module: {
-            loaders: loaders
+            rules: rules
         },
-        externals: ['jupyter-js-widgets']
+        externals: ['@jupyter-widgets/base']
     }
 ];

--- a/setup.py
+++ b/setup.py
@@ -76,9 +76,17 @@ class NPM(Command):
     def finalize_options(self):
         pass
 
+    def get_npm_name(self):
+        npm_cmd_name = 'npm'
+        if platform.system() == 'Windows':
+            npm_cmd_name = 'npm.cmd'
+
+        return npm_cmd_name
+
     def has_npm(self):
+        npm_cmd_name = self.get_npm_name()
         try:
-            check_call(['npm', '--version'])
+            check_call([npm_cmd_name, '--version'])
             return True
         except:
             return False
@@ -98,7 +106,8 @@ class NPM(Command):
 
         if self.should_run_npm_install():
             log.info("Installing build dependencies with npm.  This may take a while...")
-            check_call(['npm', 'install'], cwd=node_root, stdout=sys.stdout, stderr=sys.stderr)
+            npm_cmd_name = self.get_npm_name()
+            check_call([npm_cmd_name, 'install'], cwd=node_root, stdout=sys.stdout, stderr=sys.stderr)
             os.utime(self.node_modules, None)
 
         for t in self.targets:
@@ -129,7 +138,7 @@ setup_args = {
         ]),
     ],
     'install_requires': [
-        'ipywidgets>=6.0.0',
+        'ipywidgets>=7.0.0',
         'astropy>=1.2.0',
     ],
     'packages': find_packages(),


### PR DESCRIPTION
https://jira.lsstcorp.org/browse/DM-11341

This pull request is dealing with the changes to update firefly_widgets to work with ipywidgets 7, using plotly library from Jypiter widget environment, and making sure keyboard input into firefly dialogs does not trigger jupyter keyboard shortcuts.

- follow jupiter-widgets/widget-cookiecutter template to work with ipywidgets 7 
- use readout_format='d' for IntSlider ('i' produces an error with ipywidgets 7.0.4
- added charts widget to test plotly library load by firefly
- disable jupyter keyboard manager when chart or image widget is clicked.

I've tested it with Python 2.7 in devmode (the setup instructions are described in README.md)

Update: the latest commit is tested with py27 and py36 anaconda distribution.

Setting up python 3.6 environment:
conda create -n py36 python=3.6 anaconda
source activate py36
which python
which jupyter


Setting up Python 2.7 environment
source deactivate
conda create -n py27 python=2.7 anaconda
source activate py36

You need to rebuild firefly widgets when switching the environment. From `firefly_widgets/examples` directory:
```
cd ../js; rm -r dist node_modules; npm install
cd ../; pip install -e .; jupyter nbextension install --py --symlink --sys-prefix firefly_widgets; jupyter nbextension enable firefly_widgets --py --sys-prefix
cd examples/; jupyter notebook
```
Firefly modifications for this ticket are [here](https://github.com/Caltech-IPAC/firefly/pull/503).